### PR TITLE
feat: 多页面架构落地（活动列表/详情、响应式网格、API 扩展、404、README）

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,50 +1,163 @@
-# Mergington High School Activities API
+# Mergington High School - Activities Management System
 
-A super simple FastAPI application that allows students to view and sign up for extracurricular activities.
+一个现代化的学校课外活动管理系统，包含多页面前端和 FastAPI 后端。学生可浏览、筛选、报名和管理课外活动。
 
-## Features
+## 功能特性
 
-- View all available extracurricular activities
-- Sign up for activities
+### 前端
+- 📱 **响应式多页面设计**：主页、活动列表、活动详情、讲座、相册、评论
+- 🎨 **学校品牌配色**：白色 + 青柠绿 (`#00ff00`) 
+- 📊 **活动网格**：PC 4 列 / 平板 3 列 / 手机 1-2 列（自适应）
+- 🔍 **分类筛选**：按活动类别筛选（Strategic & Academic / Technology / Sports & Fitness / Arts & Creativity）
+- 📝 **完整管理**：报名、取消报名、实时参与者列表刷新
+- 🎯 **全卡片可点击**：点击整张卡片进入活动详情页
 
-## Getting Started
+### 后端
+- ⚡ **FastAPI 服务**：轻量级、高性能的 Python 框架
+- 📡 **RESTful API**：标准化的数据接口
+- 💾 **JSON 存储**：简单可靠的数据持久化（易于扩展至数据库）
+- 📚 **自动文档**：内置 Swagger UI 和 ReDoc
 
-1. Install the dependencies:
+## 快速开始
 
-   ```
+### 环境要求
+- Python 3.8+
+- pip（Python 包管理器）
+
+### 安装与运行
+
+1. **安装依赖**
+   ```bash
+   cd /workspaces/skills-integrate-mcp-with-copilot
    pip install fastapi uvicorn
    ```
 
-2. Run the application:
-
+2. **启动服务器**
+   ```bash
+   python3 -m uvicorn src.app:app --host 0.0.0.0 --port 8000 --reload
    ```
-   python app.py
-   ```
 
-3. Open your browser and go to:
-   - API documentation: http://localhost:8000/docs
-   - Alternative documentation: http://localhost:8000/redoc
+3. **访问应用**
+   - 🖥️ 桌面/本地: [http://localhost:8000](http://localhost:8000)
+   - 📱 移动设备/同局域网: `http://10.0.1.60:8000`（替换为实际 IP）
+   - 📖 API 文档 (Swagger): [http://localhost:8000/docs](http://localhost:8000/docs)
+   - 📘 备用文档 (ReDoc): [http://localhost:8000/redoc](http://localhost:8000/redoc)
 
-## API Endpoints
+## 项目结构
 
-| Method | Endpoint                                                          | Description                                                         |
-| ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+```
+src/
+├── app.py                          # FastAPI 应用入口
+├── activities.json                 # 活动数据（9 个活动）
+├── lectures.json                   # 讲座数据（占位符）
+├── gallery.json                    # 相册数据（占位符）
+├── testimonials.json               # 评论数据（占位符）
+└── static/
+    ├── home.html                   # 主页
+    ├── activities.html             # 活动列表页
+    ├── activity-detail.html        # 活动详情页
+    ├── lectures.html               # 讲座页
+    ├── gallery.html                # 相册页
+    ├── testimonials.html           # 评论页
+    ├── 404.html                    # 错误页面
+    ├── home.js                     # 主页逻辑
+    ├── activities-list.js          # 活动列表逻辑
+    ├── activity-detail.js          # 详情页逻辑
+    └── styles.css                  # 全局样式（843 行）
+```
 
-## Data Model
+## API 端点
 
-The application uses a simple data model with meaningful identifiers:
+| 方法 | 端点 | 描述 | 示例 |
+|------|------|------|------|
+| GET | `/activities` | 获取所有活动 | `curl http://localhost:8000/activities` |
+| GET | `/lectures` | 获取讲座列表 | `curl http://localhost:8000/lectures` |
+| GET | `/gallery` | 获取相册数据 | `curl http://localhost:8000/gallery` |
+| GET | `/testimonials` | 获取评论数据 | `curl http://localhost:8000/testimonials` |
+| POST | `/activities/{activity_name}/signup?email=...` | 学生报名活动 | `curl -X POST "http://localhost:8000/activities/Chess%20Club/signup?email=student@example.com"` |
+| DELETE | `/activities/{activity_name}/unregister?email=...` | 学生取消报名 | `curl -X DELETE "http://localhost:8000/activities/Chess%20Club/unregister?email=student@example.com"` |
 
-1. **Activities** - Uses activity name as identifier:
+## 数据模型
 
-   - Description
-   - Schedule
-   - Maximum number of participants allowed
-   - List of student emails who are signed up
+### 活动数据结构（activities.json）
+```json
+{
+  "活动名称": {
+    "description": "简短描述",
+    "schedule": "时间表（如 Fridays, 3:30 PM - 5:00 PM）",
+    "max_participants": 12,
+    "participants": ["email1@...", "email2@..."],
+    "featured": true,                    // 是否在主页显示
+    "category": "Strategic & Academic",  // 分类
+    "location": "Library Room 201",      // 地点
+    "instructor": "Mr. Anderson",        // 讲师
+    "full_description": "...",           // 完整描述
+    "tags": ["strategy", "competition"]  // 标签
+  }
+}
+```
 
-2. **Students** - Uses email as identifier:
-   - Name
-   - Grade level
+### 当前活动列表
+1. **Chess Club** - Strategic & Academic（战略与学术）
+2. **Programming Class** - Technology（技术）
+3. **Gym Class** - Sports & Fitness（体育与健身）
+4. **Soccer Team** - Sports & Fitness
+5. **Basketball Team** - Sports & Fitness
+6. **Art Club** - Arts & Creativity（艺术与创意）
+7. **Drama Club** - Arts & Creativity
+8. **Math Club** - Strategic & Academic
+9. **Debate Team** - Strategic & Academic
 
-All data is stored in memory, which means data will be reset when the server restarts.
+## 响应式设计
+
+| 设备类型 | 屏幕宽度 | 网格列数 |
+|---------|---------|---------|
+| 桌面 | ≥1200px | 4 列 |
+| 平板横屏 | 768-1199px | 3 列 |
+| 平板竖屏 | 600-767px | 2 列 |
+| 手机 | <600px | 1 列 |
+
+## 学校配色
+
+- **主色**：青柠绿 `#00ff00`（品牌色，导航、按钮、强调）
+- **次色**：深青柠 `#00cc00`（悬停、活跃状态）
+- **背景**：白色 `#ffffff`（卡片、容器）
+- **页面背景**：浅灰 `#f5f5f5`
+
+## 开发与调试
+
+### 自动热重载
+服务启动时加入 `--reload` 标志，修改代码后自动重启服务。
+
+### 浏览器开发者工具
+1. 打开 DevTools（F12）
+2. Network 选项卡查看 API 调用
+3. Console 查看 JavaScript 错误
+4. Elements 检查页面结构与样式
+
+### 常见问题
+
+**Q: 报名后未显示在参与者列表？**
+A: 页面自动刷新列表。如未刷新，检查浏览器 Console 是否有错误；确保邮箱格式正确。
+
+**Q: 添加新活动后无法显示？**
+A: 在 `activities.json` 中添加新活动对象，确保 JSON 格式正确（可用 [jsonlint.com](https://jsonlint.com) 验证）。
+
+**Q: 页面出现 404？**
+A: 检查 URL 拼写（注意大小写）；如活动名称包含特殊字符，在 URL 中需 URL 编码（如空格为 `%20`）。
+
+## 后续开发建议
+
+- [ ] **Issue #5**：实现管理员模式（登录、权限、学生/教师角色）
+- [ ] **Issue #13**：集成 Bootstrap 5 简化样式维护
+- [ ] 补充讲座、相册、评论页的实际内容
+- [ ] 添加搜索功能
+- [ ] 多条件筛选（分类 + 讲师 + 时间段）
+- [ ] 邮件通知系统
+- [ ] 数据导出（CSV/Excel）
+- [ ] 上传活动封面图片
+- [ ] 迁移至关系型数据库（SQLite / PostgreSQL）
+
+## 许可证与联系
+
+Mergington High School 2026 | All rights reserved

--- a/src/activities.json
+++ b/src/activities.json
@@ -3,54 +3,180 @@
     "description": "Learn strategies and compete in chess tournaments",
     "schedule": "Fridays, 3:30 PM - 5:00 PM",
     "max_participants": 12,
-    "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+    "participants": [
+      "daniel@mergington.edu",
+      "iendh@jfiosj.com"
+    ],
+    "featured": true,
+    "category": "Strategic & Academic",
+    "image": "chess.jpg",
+    "location": "Library Room 201",
+    "instructor": "Mr. Anderson",
+    "full_description": "Join our Chess Club to develop strategic thinking and problem-solving skills. Whether you're a beginner or an experienced player, you'll learn advanced tactics, compete in tournaments, and improve your game through regular practice sessions.",
+    "tags": [
+      "strategy",
+      "competition",
+      "critical-thinking"
+    ]
   },
   "Programming Class": {
     "description": "Learn programming fundamentals and build software projects",
     "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
     "max_participants": 20,
-    "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+    "participants": [
+      "emma@mergington.edu",
+      "sophia@mergington.edu"
+    ],
+    "featured": true,
+    "category": "Technology",
+    "image": "programming.jpg",
+    "location": "Computer Lab A",
+    "instructor": "Ms. Johnson",
+    "full_description": "Dive into the world of coding! Learn Python, JavaScript, and web development. Build real projects, collaborate with peers, and prepare for tech careers or advanced CS courses.",
+    "tags": [
+      "coding",
+      "technology",
+      "career-prep"
+    ]
   },
   "Gym Class": {
     "description": "Physical education and sports activities",
     "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
     "max_participants": 30,
-    "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    "participants": [
+      "john@mergington.edu",
+      "olivia@mergington.edu"
+    ],
+    "featured": false,
+    "category": "Sports & Fitness",
+    "image": "gym.jpg",
+    "location": "Main Gymnasium",
+    "instructor": "Coach Williams",
+    "full_description": "Stay active and healthy! Our gym class offers a variety of physical activities including cardio, strength training, team sports, and fitness challenges.",
+    "tags": [
+      "fitness",
+      "health",
+      "sports"
+    ]
   },
   "Soccer Team": {
     "description": "Join the school soccer team and compete in matches",
     "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
     "max_participants": 22,
-    "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    "participants": [
+      "liam@mergington.edu",
+      "noah@mergington.edu"
+    ],
+    "featured": true,
+    "category": "Sports & Fitness",
+    "image": "soccer.jpg",
+    "location": "Sports Field",
+    "instructor": "Coach Martinez",
+    "full_description": "Be part of Mergington's competitive soccer team! Train with experienced coaches, compete against other schools, and develop teamwork and athletic skills.",
+    "tags": [
+      "soccer",
+      "team-sport",
+      "competition"
+    ]
   },
   "Basketball Team": {
     "description": "Practice and play basketball with the school team",
     "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
     "max_participants": 15,
-    "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+    "participants": [
+      "ava@mergington.edu",
+      "mia@mergington.edu"
+    ],
+    "featured": false,
+    "category": "Sports & Fitness",
+    "image": "basketball.jpg",
+    "location": "Main Gymnasium",
+    "instructor": "Coach Davis",
+    "full_description": "Join our basketball team and improve your skills through drills, scrimmages, and competitive games. All skill levels welcome!",
+    "tags": [
+      "basketball",
+      "team-sport",
+      "athletic"
+    ]
   },
   "Art Club": {
     "description": "Explore your creativity through painting and drawing",
     "schedule": "Thursdays, 3:30 PM - 5:00 PM",
     "max_participants": 15,
-    "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    "participants": [
+      "amelia@mergington.edu",
+      "harper@mergington.edu"
+    ],
+    "featured": true,
+    "category": "Arts & Creativity",
+    "image": "art.jpg",
+    "location": "Art Studio 102",
+    "instructor": "Ms. Chen",
+    "full_description": "Unleash your artistic potential! Learn various painting and drawing techniques, work on personal projects, and showcase your art in our annual exhibition.",
+    "tags": [
+      "painting",
+      "drawing",
+      "creativity"
+    ]
   },
   "Drama Club": {
     "description": "Act, direct, and produce plays and performances",
     "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
     "max_participants": 20,
-    "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+    "participants": [
+      "ella@mergington.edu",
+      "scarlett@mergington.edu"
+    ],
+    "featured": false,
+    "category": "Arts & Creativity",
+    "image": "drama.jpg",
+    "location": "School Auditorium",
+    "instructor": "Mr. Thompson",
+    "full_description": "Experience the magic of theater! Act in productions, learn stagecraft, and develop confidence through performance arts.",
+    "tags": [
+      "theater",
+      "acting",
+      "performance"
+    ]
   },
   "Math Club": {
     "description": "Solve challenging problems and participate in math competitions",
     "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
     "max_participants": 10,
-    "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+    "participants": [
+      "james@mergington.edu",
+      "benjamin@mergington.edu"
+    ],
+    "featured": false,
+    "category": "Strategic & Academic",
+    "image": "math.jpg",
+    "location": "Room 305",
+    "instructor": "Dr. Lee",
+    "full_description": "Challenge yourself with advanced mathematics! Prepare for competitions, explore mathematical concepts beyond the curriculum, and connect with fellow math enthusiasts.",
+    "tags": [
+      "mathematics",
+      "problem-solving",
+      "competition"
+    ]
   },
   "Debate Team": {
     "description": "Develop public speaking and argumentation skills",
     "schedule": "Fridays, 4:00 PM - 5:30 PM",
     "max_participants": 12,
-    "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    "participants": [
+      "charlotte@mergington.edu",
+      "henry@mergington.edu"
+    ],
+    "featured": true,
+    "category": "Strategic & Academic",
+    "image": "debate.jpg",
+    "location": "Room 401",
+    "instructor": "Ms. Rodriguez",
+    "full_description": "Master the art of persuasion and critical thinking! Participate in debates, compete in tournaments, and develop essential communication skills for college and beyond.",
+    "tags": [
+      "debate",
+      "public-speaking",
+      "critical-thinking"
+    ]
   }
 }

--- a/src/app.py
+++ b/src/app.py
@@ -39,14 +39,40 @@ activities = load_activities()
 
 @app.get("/")
 def root():
-    return RedirectResponse(url="/static/index.html")
+    """Redirect to the new multi-page homepage"""
+    return RedirectResponse(url="/static/home.html")
 
 
 @app.get("/activities")
 def get_activities():
+    """Get all activities data"""
     # Reload activities to get latest data
     activities = load_activities()
     return activities
+
+
+@app.get("/lectures")
+def get_lectures():
+    """Get all lectures data"""
+    lectures_file = os.path.join(current_dir, "lectures.json")
+    with open(lectures_file, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+@app.get("/gallery")
+def get_gallery():
+    """Get all gallery items"""
+    gallery_file = os.path.join(current_dir, "gallery.json")
+    with open(gallery_file, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+@app.get("/testimonials")
+def get_testimonials():
+    """Get all testimonials"""
+    testimonials_file = os.path.join(current_dir, "testimonials.json")
+    with open(testimonials_file, 'r', encoding='utf-8') as f:
+        return json.load(f)
 
 
 @app.post("/activities/{activity_name}/signup")

--- a/src/app.py
+++ b/src/app.py
@@ -55,24 +55,39 @@ def get_activities():
 def get_lectures():
     """Get all lectures data"""
     lectures_file = os.path.join(current_dir, "lectures.json")
-    with open(lectures_file, 'r', encoding='utf-8') as f:
-        return json.load(f)
+    try:
+        with open(lectures_file, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Lectures data file not found")
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=500, detail="Invalid lectures data format")
 
 
 @app.get("/gallery")
 def get_gallery():
     """Get all gallery items"""
     gallery_file = os.path.join(current_dir, "gallery.json")
-    with open(gallery_file, 'r', encoding='utf-8') as f:
-        return json.load(f)
+    try:
+        with open(gallery_file, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Gallery data file not found")
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=500, detail="Invalid gallery data format")
 
 
 @app.get("/testimonials")
 def get_testimonials():
     """Get all testimonials"""
     testimonials_file = os.path.join(current_dir, "testimonials.json")
-    with open(testimonials_file, 'r', encoding='utf-8') as f:
-        return json.load(f)
+    try:
+        with open(testimonials_file, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Testimonials data file not found")
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=500, detail="Invalid testimonials data format")
 
 
 @app.post("/activities/{activity_name}/signup")

--- a/src/gallery.json
+++ b/src/gallery.json
@@ -1,0 +1,12 @@
+{
+  "items": [
+    {
+      "id": "placeholder-1",
+      "type": "placeholder",
+      "title": "Gallery Coming Soon",
+      "description": "Photos and videos from our activities will be added here soon!",
+      "activity": null,
+      "date": null
+    }
+  ]
+}

--- a/src/lectures.json
+++ b/src/lectures.json
@@ -1,0 +1,19 @@
+{
+  "lectures": [
+    {
+      "id": "lecture-1",
+      "name": "Coming Soon",
+      "title": "Upcoming Guest Speaker",
+      "description": "Stay tuned for announcements about our next inspiring guest speaker!",
+      "image": "placeholder.jpg",
+      "date": "TBD",
+      "status": "coming-soon",
+      "activity": null,
+      "social": {
+        "linkedin": "",
+        "instagram": "",
+        "twitter": ""
+      }
+    }
+  ]
+}

--- a/src/static/404.html
+++ b/src/static/404.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>404 - Page Not Found</title>
+    <link rel="stylesheet" href="styles.css" />
+    <style>
+      .error-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: calc(100vh - 120px);
+        padding: 2rem;
+        text-align: center;
+      }
+
+      .error-code {
+        font-size: 8rem;
+        font-weight: bold;
+        color: #00ff00;
+        margin: 0;
+        line-height: 1;
+        text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+      }
+
+      .error-title {
+        font-size: 2rem;
+        color: #2c3e50;
+        margin: 1rem 0;
+      }
+
+      .error-description {
+        font-size: 1.1rem;
+        color: #555;
+        margin-bottom: 2rem;
+        max-width: 500px;
+      }
+
+      .error-actions {
+        display: flex;
+        gap: 1rem;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
+      .btn {
+        padding: 0.75rem 1.5rem;
+        font-size: 1rem;
+        font-weight: 600;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: background-color 0.3s;
+        text-decoration: none;
+        display: inline-block;
+      }
+
+      .btn-primary {
+        background-color: #00ff00;
+        color: #333;
+      }
+
+      .btn-primary:hover {
+        background-color: #00cc00;
+      }
+
+      .btn-secondary {
+        background-color: #ecf0f1;
+        color: #333;
+        border: 2px solid #bdc3c7;
+      }
+
+      .btn-secondary:hover {
+        background-color: #d5dbdb;
+      }
+
+      .error-suggestions {
+        margin-top: 3rem;
+        padding: 2rem;
+        background-color: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        max-width: 500px;
+      }
+
+      .error-suggestions h3 {
+        color: #2c3e50;
+        margin-top: 0;
+      }
+
+      .error-suggestions ul {
+        text-align: left;
+        list-style: none;
+        padding: 0;
+      }
+
+      .error-suggestions li {
+        padding: 0.5rem 0;
+        color: #555;
+      }
+
+      .error-suggestions li:before {
+        content: "→ ";
+        color: #00ff00;
+        font-weight: bold;
+        margin-right: 0.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Navigation -->
+    <nav class="navbar">
+      <div class="container">
+        <a href="home.html" class="logo">
+          <h2>Mergington High School</h2>
+        </a>
+        <ul class="nav-links">
+          <li><a href="home.html">Home</a></li>
+          <li><a href="activities.html">Activities</a></li>
+          <li><a href="lectures.html">Lectures</a></li>
+          <li><a href="gallery.html">Gallery</a></li>
+          <li><a href="testimonials.html">Testimonials</a></li>
+        </ul>
+      </div>
+    </nav>
+
+    <!-- Error Content -->
+    <main class="container error-container">
+      <h1 class="error-code">404</h1>
+      <h2 class="error-title">Page Not Found</h2>
+      <p class="error-description">
+        Oops! The page you're looking for doesn't exist or has been moved.
+      </p>
+
+      <div class="error-actions">
+        <a href="home.html" class="btn btn-primary">Go to Home</a>
+        <a href="activities.html" class="btn btn-secondary">Browse Activities</a>
+      </div>
+
+      <div class="error-suggestions">
+        <h3>What can you do?</h3>
+        <ul>
+          <li>Check the URL for typos</li>
+          <li>Return to the <a href="home.html" style="color: #00ff00; text-decoration: underline;">home page</a></li>
+          <li>Browse our <a href="activities.html" style="color: #00ff00; text-decoration: underline;">activities</a></li>
+          <li>If you think this is an error, please contact us</li>
+        </ul>
+      </div>
+    </main>
+
+    <!-- Footer -->
+    <footer>
+      <div class="container">
+        <p>&copy; 2026 Mergington High School. All rights reserved.</p>
+        <p>Building futures through excellence in education</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/src/static/activities-list.js
+++ b/src/static/activities-list.js
@@ -1,0 +1,79 @@
+// Activities list page JavaScript
+document.addEventListener("DOMContentLoaded", async () => {
+  await loadActivities();
+  setupFilters();
+});
+
+let allActivities = {};
+
+async function loadActivities() {
+  try {
+    const response = await fetch("/activities");
+    allActivities = await response.json();
+    displayActivities(allActivities);
+  } catch (error) {
+    console.error("Error loading activities:", error);
+    document.getElementById("activities-grid").innerHTML =
+      "<p>Failed to load activities. Please try again later.</p>";
+  }
+}
+
+function displayActivities(activities) {
+  const grid = document.getElementById("activities-grid");
+  grid.innerHTML = "";
+
+  const entries = Object.entries(activities);
+  
+  if (entries.length === 0) {
+    grid.innerHTML = "<p>No activities found.</p>";
+    return;
+  }
+
+  entries.forEach(([name, details]) => {
+    const card = createActivityCard(name, details);
+    grid.appendChild(card);
+  });
+}
+
+function createActivityCard(name, details) {
+  const spotsLeft = details.max_participants - details.participants.length;
+
+  const card = document.createElement("a");
+  card.href = `activity-detail.html?name=${encodeURIComponent(name)}`;
+  card.className = "activity-card";
+
+  card.innerHTML = `
+    <div class="activity-card-header">
+      <h3>${name}</h3>
+      <span class="category-badge">${details.category || "General"}</span>
+    </div>
+    <p class="activity-description">${details.description}</p>
+    <div class="activity-meta">
+      <p><strong>📅</strong> ${details.schedule}</p>
+      <p><strong>📍</strong> ${details.location || "TBD"}</p>
+      <p><strong>👥</strong> ${spotsLeft} spots left</p>
+    </div>
+    <div class="activity-card-action">View Details & Sign Up →</div>
+  `;
+
+  return card;
+}
+
+function setupFilters() {
+  const categoryFilter = document.getElementById("category-filter");
+  
+  categoryFilter.addEventListener("change", (e) => {
+    const selectedCategory = e.target.value;
+    
+    if (selectedCategory === "all") {
+      displayActivities(allActivities);
+    } else {
+      const filtered = Object.fromEntries(
+        Object.entries(allActivities).filter(
+          ([_, details]) => details.category === selectedCategory
+        )
+      );
+      displayActivities(filtered);
+    }
+  });
+}

--- a/src/static/activities.html
+++ b/src/static/activities.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Activities - Mergington High School</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <nav class="navbar">
+      <div class="container">
+        <a href="home.html" class="logo">
+          <h2>Mergington High School</h2>
+        </a>
+        <ul class="nav-links">
+          <li><a href="home.html">Home</a></li>
+          <li><a href="activities.html" class="active">Activities</a></li>
+          <li><a href="lectures.html">Lectures</a></li>
+          <li><a href="gallery.html">Gallery</a></li>
+          <li><a href="testimonials.html">Testimonials</a></li>
+        </ul>
+      </div>
+    </nav>
+
+    <!-- Page Header -->
+    <header class="page-header">
+      <div class="container">
+        <h1>All Activities</h1>
+        <p>Find the perfect activity that matches your interests</p>
+      </div>
+    </header>
+
+    <main class="container activities-layout">
+      <!-- Filter Section -->
+      <aside class="filter-section">
+        <div class="filter-controls">
+          <label for="category-filter">Filter by Category:</label>
+          <select id="category-filter">
+            <option value="all">All Categories</option>
+            <option value="Strategic & Academic">Strategic & Academic</option>
+            <option value="Technology">Technology</option>
+            <option value="Sports & Fitness">Sports & Fitness</option>
+            <option value="Arts & Creativity">Arts & Creativity</option>
+          </select>
+        </div>
+      </aside>
+
+      <!-- Activities Grid -->
+      <section class="activities-list">
+        <div id="activities-grid" class="activities-grid">
+          <p>Loading activities...</p>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer>
+      <div class="container">
+        <p>&copy; 2026 Mergington High School. All rights reserved.</p>
+        <p>Building futures through excellence in education</p>
+      </div>
+    </footer>
+
+    <script src="activities-list.js"></script>
+  </body>
+</html>

--- a/src/static/activity-detail.html
+++ b/src/static/activity-detail.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title id="page-title">Activity Details - Mergington High School</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <nav class="navbar">
+      <div class="container">
+        <a href="home.html" class="logo">
+          <h2>Mergington High School</h2>
+        </a>
+        <ul class="nav-links">
+          <li><a href="home.html">Home</a></li>
+          <li><a href="activities.html" class="active">Activities</a></li>
+          <li><a href="lectures.html">Lectures</a></li>
+          <li><a href="gallery.html">Gallery</a></li>
+          <li><a href="testimonials.html">Testimonials</a></li>
+        </ul>
+      </div>
+    </nav>
+
+    <!-- Activity Hero -->
+    <header class="activity-hero">
+      <div class="container">
+        <div class="breadcrumb">
+          <a href="home.html">Home</a> / 
+          <a href="activities.html">Activities</a> / 
+          <span id="activity-breadcrumb">Loading...</span>
+        </div>
+        <h1 id="activity-title">Loading...</h1>
+        <p id="activity-category" class="activity-category-badge"></p>
+      </div>
+    </header>
+
+    <main class="container activity-detail-container">
+      <div class="activity-detail-grid">
+        <!-- Left Column: Main Info -->
+        <div class="activity-main-content">
+          <section class="activity-section">
+            <h2>About This Activity</h2>
+            <p id="activity-full-description" class="activity-description"></p>
+          </section>
+
+          <section class="activity-section">
+            <h2>Details</h2>
+            <div class="details-grid">
+              <div class="detail-item">
+                <strong>📅 Schedule:</strong>
+                <span id="activity-schedule"></span>
+              </div>
+              <div class="detail-item">
+                <strong>📍 Location:</strong>
+                <span id="activity-location"></span>
+              </div>
+              <div class="detail-item">
+                <strong>👨‍🏫 Instructor:</strong>
+                <span id="activity-instructor"></span>
+              </div>
+              <div class="detail-item">
+                <strong>👥 Availability:</strong>
+                <span id="activity-availability"></span>
+              </div>
+            </div>
+          </section>
+
+          <section class="activity-section">
+            <h2>Current Participants</h2>
+            <div id="participants-list" class="participants-list">
+              <p>Loading participants...</p>
+            </div>
+          </section>
+        </div>
+
+        <!-- Right Column: Signup Form -->
+        <div class="activity-sidebar">
+          <div class="signup-card">
+            <h3>Join This Activity</h3>
+            <form id="signup-form" class="signup-form">
+              <div class="form-group">
+                <label for="email">Student Email:</label>
+                <input 
+                  type="email" 
+                  id="email" 
+                  required 
+                  placeholder="your-email@mergington.edu" 
+                />
+              </div>
+              <button type="submit" class="btn btn-primary btn-block">Sign Up Now</button>
+            </form>
+            <div id="message" class="message hidden"></div>
+          </div>
+
+          <div class="info-card">
+            <h4>Tags</h4>
+            <div id="activity-tags" class="tags-container"></div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Footer -->
+    <footer>
+      <div class="container">
+        <p>&copy; 2026 Mergington High School. All rights reserved.</p>
+        <p>Building futures through excellence in education</p>
+      </div>
+    </footer>
+
+    <script src="activity-detail.js"></script>
+  </body>
+</html>

--- a/src/static/activity-detail.js
+++ b/src/static/activity-detail.js
@@ -92,7 +92,7 @@ function displayParticipants(participants, activityName) {
           (email) => `
         <li class="participant-item">
           <span class="participant-email">${email}</span>
-          <button class="delete-btn" data-activity="${activityName}" data-email="${email}">
+          <button class="delete-btn" data-activity="${activityName}" data-email="${email}" aria-label="Remove participant">
             ❌
           </button>
         </li>

--- a/src/static/activity-detail.js
+++ b/src/static/activity-detail.js
@@ -1,0 +1,194 @@
+// Activity detail page JavaScript
+document.addEventListener("DOMContentLoaded", async () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const activityName = urlParams.get("name");
+
+  if (!activityName) {
+    window.location.href = "activities.html";
+    return;
+  }
+
+  await loadActivityDetail(activityName);
+  setupSignupForm(activityName);
+});
+
+async function loadActivityDetail(activityName) {
+  try {
+    const response = await fetch("/activities");
+    const activities = await response.json();
+
+    if (!activities[activityName]) {
+      alert("Activity not found");
+      window.location.href = "activities.html";
+      return;
+    }
+
+    const activity = activities[activityName];
+    displayActivityDetail(activityName, activity);
+  } catch (error) {
+    console.error("Error loading activity details:", error);
+    alert("Failed to load activity details");
+  }
+}
+
+function displayActivityDetail(name, details) {
+  // Update page title
+  document.getElementById("page-title").textContent = `${name} - Mergington High School`;
+  document.getElementById("activity-title").textContent = name;
+  document.getElementById("activity-breadcrumb").textContent = name;
+
+  // Update category
+  const categoryBadge = document.getElementById("activity-category");
+  categoryBadge.textContent = details.category || "General";
+  categoryBadge.className = "activity-category-badge";
+
+  // Update description
+  document.getElementById("activity-full-description").textContent =
+    details.full_description || details.description;
+
+  // Update details
+  document.getElementById("activity-schedule").textContent = details.schedule;
+  document.getElementById("activity-location").textContent = details.location || "TBD";
+  document.getElementById("activity-instructor").textContent = details.instructor || "TBD";
+
+  // Update availability
+  const spotsLeft = details.max_participants - details.participants.length;
+  const availabilityElement = document.getElementById("activity-availability");
+  availabilityElement.textContent = `${spotsLeft} spots available (${details.participants.length}/${details.max_participants})`;
+
+  if (spotsLeft === 0) {
+    availabilityElement.style.color = "#c62828";
+    availabilityElement.textContent += " - FULL";
+    document.querySelector("#signup-form button").disabled = true;
+    document.querySelector("#signup-form button").textContent = "Activity Full";
+  }
+
+  // Update tags
+  const tagsContainer = document.getElementById("activity-tags");
+  if (details.tags && details.tags.length > 0) {
+    tagsContainer.innerHTML = details.tags
+      .map((tag) => `<span class="tag">${tag}</span>`)
+      .join("");
+  } else {
+    tagsContainer.innerHTML = "<p>No tags available</p>";
+  }
+
+  // Update participants list
+  displayParticipants(details.participants, name);
+}
+
+function displayParticipants(participants, activityName) {
+  const participantsList = document.getElementById("participants-list");
+
+  if (participants.length === 0) {
+    participantsList.innerHTML = "<p><em>No participants yet. Be the first to join!</em></p>";
+    return;
+  }
+
+  participantsList.innerHTML = `
+    <ul class="participants-ul">
+      ${participants
+        .map(
+          (email) => `
+        <li class="participant-item">
+          <span class="participant-email">${email}</span>
+          <button class="delete-btn" data-activity="${activityName}" data-email="${email}">
+            ❌
+          </button>
+        </li>
+      `
+        )
+        .join("")}
+    </ul>
+  `;
+
+  // Add event listeners to delete buttons
+  document.querySelectorAll(".delete-btn").forEach((button) => {
+    button.addEventListener("click", handleUnregister);
+  });
+}
+
+function setupSignupForm(activityName) {
+  const form = document.getElementById("signup-form");
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+
+    const email = document.getElementById("email").value;
+    const messageDiv = document.getElementById("message");
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activityName)}/signup?email=${encodeURIComponent(email)}`,
+        {
+          method: "POST",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "message success";
+        form.reset();
+
+        // Refresh activity details
+        await loadActivityDetail(activityName);
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "message error";
+      }
+
+      messageDiv.classList.remove("hidden");
+
+      // Hide message after 5 seconds
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to sign up. Please try again.";
+      messageDiv.className = "message error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error signing up:", error);
+    }
+  });
+}
+
+async function handleUnregister(event) {
+  const button = event.target;
+  const activity = button.getAttribute("data-activity");
+  const email = button.getAttribute("data-email");
+
+  if (!confirm(`Remove ${email} from ${activity}?`)) {
+    return;
+  }
+
+  try {
+    const response = await fetch(
+      `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
+      {
+        method: "DELETE",
+      }
+    );
+
+    const result = await response.json();
+
+    if (response.ok) {
+      // Refresh activity details
+      await loadActivityDetail(activity);
+      
+      const messageDiv = document.getElementById("message");
+      messageDiv.textContent = result.message;
+      messageDiv.className = "message success";
+      messageDiv.classList.remove("hidden");
+
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } else {
+      alert(result.detail || "Failed to unregister");
+    }
+  } catch (error) {
+    alert("Failed to unregister. Please try again.");
+    console.error("Error unregistering:", error);
+  }
+}

--- a/src/static/gallery.html
+++ b/src/static/gallery.html
@@ -32,8 +32,8 @@
     </header>
 
     <main class="container">
-      <section class="coming-soon-section">
-        <div class="coming-soon-card">
+      <section class="coming-soon">
+        <div class="coming-soon">
           <h2>📸 Coming Soon!</h2>
           <p>Our gallery will feature photos and videos from all our amazing activities and events.</p>
           <p>Check back soon to see your participation showcased!</p>

--- a/src/static/gallery.html
+++ b/src/static/gallery.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gallery - Mergington High School</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <nav class="navbar">
+      <div class="container">
+        <a href="home.html" class="logo">
+          <h2>Mergington High School</h2>
+        </a>
+        <ul class="nav-links">
+          <li><a href="home.html">Home</a></li>
+          <li><a href="activities.html">Activities</a></li>
+          <li><a href="lectures.html">Lectures</a></li>
+          <li><a href="gallery.html" class="active">Gallery</a></li>
+          <li><a href="testimonials.html">Testimonials</a></li>
+        </ul>
+      </div>
+    </nav>
+
+    <!-- Page Header -->
+    <header class="page-header">
+      <div class="container">
+        <h1>Photo & Video Gallery</h1>
+        <p>Explore moments from our activities and events</p>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="coming-soon-section">
+        <div class="coming-soon-card">
+          <h2>📸 Coming Soon!</h2>
+          <p>Our gallery will feature photos and videos from all our amazing activities and events.</p>
+          <p>Check back soon to see your participation showcased!</p>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer>
+      <div class="container">
+        <p>&copy; 2026 Mergington High School. All rights reserved.</p>
+        <p>Building futures through excellence in education</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/src/static/home.html
+++ b/src/static/home.html
@@ -27,7 +27,7 @@
     <header class="hero">
       <div class="container">
         <h1>Discover Your Passion</h1>
-        <p class="hero-subtitle">Join our vibrant community of learners, athletes, and creators</p>
+        <p class="section-subtitle">Join our vibrant community of learners, athletes, and creators</p>
         <a href="activities.html" class="btn btn-primary">Explore Activities</a>
       </div>
     </header>

--- a/src/static/home.html
+++ b/src/static/home.html
@@ -42,7 +42,7 @@
           <p>Loading featured activities...</p>
         </div>
 
-        <div class="text-center" style="margin-top: 30px;">
+        <div style="margin-top: 30px; text-align: center;">
           <a href="activities.html" class="btn btn-secondary">View All Activities</a>
         </div>
       </div>

--- a/src/static/home.html
+++ b/src/static/home.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mergington High School - Extracurricular Activities</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <nav class="navbar">
+      <div class="container">
+        <a href="home.html" class="logo">
+          <h2>Mergington High School</h2>
+        </a>
+        <ul class="nav-links">
+          <li><a href="home.html" class="active">Home</a></li>
+          <li><a href="activities.html">Activities</a></li>
+          <li><a href="lectures.html">Lectures</a></li>
+          <li><a href="gallery.html">Gallery</a></li>
+          <li><a href="testimonials.html">Testimonials</a></li>
+        </ul>
+      </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <header class="hero">
+      <div class="container">
+        <h1>Discover Your Passion</h1>
+        <p class="hero-subtitle">Join our vibrant community of learners, athletes, and creators</p>
+        <a href="activities.html" class="btn btn-primary">Explore Activities</a>
+      </div>
+    </header>
+
+    <!-- Featured Activities -->
+    <section class="featured-activities">
+      <div class="container">
+        <h2 class="section-title">Featured Activities</h2>
+        <p class="section-subtitle">Start your journey with our most popular programs</p>
+        
+        <div id="featured-activities-grid" class="activities-grid">
+          <p>Loading featured activities...</p>
+        </div>
+
+        <div class="text-center" style="margin-top: 30px;">
+          <a href="activities.html" class="btn btn-secondary">View All Activities</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Footer -->
+    <footer>
+      <div class="container">
+        <p>&copy; 2026 Mergington High School. All rights reserved.</p>
+        <p>Building futures through excellence in education</p>
+      </div>
+    </footer>
+
+    <script src="home.js"></script>
+  </body>
+</html>

--- a/src/static/home.html
+++ b/src/static/home.html
@@ -43,7 +43,7 @@
         </div>
 
         <div style="margin-top: 30px; text-align: center;">
-          <a href="activities.html" class="btn btn-secondary">View All Activities</a>
+          <a href="activities.html" class="btn-primary">View All Activities</a>
         </div>
       </div>
     </section>

--- a/src/static/home.js
+++ b/src/static/home.js
@@ -1,0 +1,76 @@
+// Home page JavaScript
+document.addEventListener("DOMContentLoaded", async () => {
+  await loadFeaturedActivities();
+});
+
+async function loadFeaturedActivities() {
+  try {
+    const response = await fetch("/activities");
+    const activities = await response.json();
+
+    const featuredGrid = document.getElementById("featured-activities-grid");
+    featuredGrid.innerHTML = "";
+
+    // Filter featured activities
+    const featured = Object.entries(activities).filter(
+      ([_, details]) => details.featured === true
+    );
+
+    if (featured.length === 0) {
+      featuredGrid.innerHTML = "<p>No featured activities at this time.</p>";
+      return;
+    }
+
+    featured.forEach(([name, details]) => {
+      const card = createActivityCard(name, details);
+      featuredGrid.appendChild(card);
+    });
+  } catch (error) {
+    console.error("Error loading featured activities:", error);
+    document.getElementById("featured-activities-grid").innerHTML =
+      "<p>Failed to load activities. Please try again later.</p>";
+  }
+}
+
+function createActivityCard(name, details) {
+  const spotsLeft = details.max_participants - details.participants.length;
+
+  const card = document.createElement("a");
+  card.href = `activity-detail.html?name=${encodeURIComponent(name)}`;
+  card.className = "activity-card";
+
+  card.innerHTML = `
+    <div class="activity-card-header">
+      <h3>${name}</h3>
+      <span class="category-badge">${details.category || "General"}</span>
+    </div>
+    <p class="activity-description">${details.description}</p>
+    <div class="activity-meta">
+      <p><strong>📅</strong> ${details.schedule}</p>
+      <p><strong>👥</strong> ${spotsLeft} spots left</p>
+    </div>
+    <div class="activity-card-action">View Details →</div>
+  `;
+
+  return card;
+}
+
+async function loadStats() {
+  try {
+    const response = await fetch("/activities");
+    const activities = await response.json();
+
+    // Count total activities
+    const totalActivities = Object.keys(activities).length;
+    document.getElementById("total-activities").textContent = `${totalActivities}+`;
+
+    // Count total participants
+    const totalParticipants = Object.values(activities).reduce(
+      (sum, activity) => sum + activity.participants.length,
+      0
+    );
+    document.getElementById("total-participants").textContent = `${totalParticipants}+`;
+  } catch (error) {
+    console.error("Error loading stats:", error);
+  }
+}

--- a/src/static/lectures.html
+++ b/src/static/lectures.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lectures - Mergington High School</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <nav class="navbar">
+      <div class="container">
+        <a href="home.html" class="logo">
+          <h2>Mergington High School</h2>
+        </a>
+        <ul class="nav-links">
+          <li><a href="home.html">Home</a></li>
+          <li><a href="activities.html">Activities</a></li>
+          <li><a href="lectures.html" class="active">Lectures</a></li>
+          <li><a href="gallery.html">Gallery</a></li>
+          <li><a href="testimonials.html">Testimonials</a></li>
+        </ul>
+      </div>
+    </nav>
+
+    <!-- Page Header -->
+    <header class="page-header">
+      <div class="container">
+        <h1>Guest Lectures & Talks</h1>
+        <p>Learn from accomplished professionals and industry leaders</p>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="coming-soon-section">
+        <div class="coming-soon-card">
+          <h2>🎤 Coming Soon!</h2>
+          <p>We're planning exciting guest speaker sessions and inspiring talks from accomplished professionals.</p>
+          <p>Stay tuned for announcements!</p>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer>
+      <div class="container">
+        <p>&copy; 2026 Mergington High School. All rights reserved.</p>
+        <p>Building futures through excellence in education</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -1,27 +1,665 @@
+/* ==================== Base Styles ==================== */
+/*
+ * ====== 布局宽度问题分析 ======
+ * 
+ * 问题：为什么内容看起来很窄？
+ * 
+ * 关键因素：
+ * 1. body padding-top: 60px - 为固定导航栏留空间
+ * 2. .container 有 padding: 0 2rem - 左右各减少 32px (2rem = 32px)
+ * 3. .activities-layout 网格 - 250px 左列 + gap 32px + 右列
+ * 
+ * 实际宽度计算示例 (1400px 屏幕宽度)：
+ * ┌─────────────────────────────────────┐
+ * │ 整个视口: 1400px                     │
+ * │ .container padding: 左32px + 右32px   │
+ * │ 可用宽度: 1400 - 64 = 1336px         │
+ * ├──────────────┬──────────────────────┤
+ * │ 筛选器       │ 活动列表              │
+ * │ 250px        │ 1054px                │
+ * │              │ (gap 32px included)   │
+ * └──────────────┴──────────────────────┘
+ * 
+ * 在活动列表 (1054px) 内部：
+ * - .activities-list padding: 2rem (32px 左右)
+ * - 实际卡片容器宽度: 1054 - 64 = 990px
+ * - 这 990px 显示 4 列卡片
+ * - 每列平均: 990 / 4 ≈ 247px
+ * - 加上 gap: 2rem = 32px，所以实际宽度受限
+ * 
+ * 关键点：虽然宽度是响应式的，但由于多层 padding 和固定列数，
+ * 看起来会比较紧凑。这是正常的设计。
+ */
+
 * {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  font-family: Arial, sans-serif;
 }
 
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.6;
   color: #333;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 20px;
   background-color: #f5f5f5;
+  padding-top: 60px; /* Space for fixed navbar */
 }
 
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+/* ==================== Navigation Bar ==================== */
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background-color: #ffffff;
+  padding: 1rem 2rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+}
+
+.navbar .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.navbar-brand,
+.logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #00ff00;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.logo h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.navbar-menu,
+.nav-links {
+  display: flex;
+  gap: 2rem;
+  list-style: none;
+  flex-direction: row;
+  margin: 0;
+  padding: 0;
+}
+
+.navbar-menu a,
+.nav-links a {
+  color: #333;
+  font-weight: 600;
+  transition: color 0.3s;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}
+
+.navbar-menu a:hover,
+.navbar-menu a.active,
+.nav-links a:hover,
+.nav-links a.active {
+  color: #00ff00;
+  background-color: rgba(0, 255, 0, 0.1);
+}
+
+/* ==================== Hero Section ==================== */
+/* 
+ * 主页的顶部 Hero 区域
+ * - 青柠绿渐变背景
+ * - 大标题 + 副标题 + 按钮
+ * 
+ * 此处无宽度限制，会横跨整个视口宽度
+ */
+.hero {
+  background: linear-gradient(135deg, #00ff00 0%, #00cc00 100%);
+  color: #333;
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: #ffffff;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.hero p {
+  font-size: 1.2rem;
+  opacity: 0.95;
+  color: #ffffff;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+/* ==================== Featured Activities (Home Page) ==================== */
+/* 
+ * .featured-activities - 主页的精选活动区域（白色背景）
+ * 
+ * HTML 结构：
+ * <section class="featured-activities">
+ *   <div class="container">
+ *     <h2>Featured Activities</h2>
+ *     <div id="featured-activities-grid" class="activities-grid">
+ *       [卡片在这里，显示 1-4 列]
+ *     </div>
+ *   </div>
+ * </section>
+ * 
+ * 布局说明：
+ * - 白色背景区域（与活动列表页的卡片一致）
+ * - 内部有 .container，会有左右 2rem (32px) padding
+ * - .activities-grid 根据屏幕宽度显示 1-4 列卡片
+ * 
+ * 为什么看起来窄？
+ * - .container padding: 0 2rem 会减少有效宽度
+ * - .activities-grid 上面的约束在大屏幕强制 4 列
+ * - 每列 minmax(280px, 1fr) 或强制列数限制实际宽度
+ */
+.featured-activities {
+  background-color: white;            /* 白色背景，与活动卡片一致 */
+  padding: 3rem 0;                    /* 上下内边距：48px */
+  border-radius: 8px;
+  margin: 2rem 0;
+}
+
+/* ==================== Page Breadcrumb ==================== */
+.breadcrumb {
+  background-color: #ecf0f1;
+  padding: 1rem 2rem;
+}
+
+.breadcrumb-container {
+  /* 已删除：max-width: 1200px; - 旧限制不适用新架构 */
+  /* 新架构用 .container { max-width: 100%; } 控制宽度 */
+  margin: 0 auto;
+  font-size: 0.9rem;
+  padding: 0 2rem;  /* 与 .container 保持一致的 padding */
+}
+
+.breadcrumb a {
+  color: #3498db;
+}
+
+.breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+/* ==================== Main Container ==================== */
+/* 
+ * .container - 所有页面的主容器
+ * 注意：padding: 0 2rem 会在左右各减少 2rem (32px) 的宽度
+ * 例如：在 1400px 屏幕上，实际内容宽度 = 1400 - 64px = 1336px
+ */
+.container {
+  max-width: 100%;
+  margin: 0 auto;
+  padding: 0 2rem;        /* 左右各 32px 的内边距 */
+  width: 100%;
+}
+
+/* 
+ * .activities-layout - 活动列表页面的两列布局
+ * 左列：250px（固定宽度筛选器）
+ * 右列：1fr（剩余空间）
+ * 
+ * ======= 什么是 1fr？=======
+ * fr = fractional unit（分数单位）
+ * 1fr 表示占用所有"剩余空间"的 1 份
+ * 
+ * 例如：grid-template-columns: 250px 1fr
+ * 意思是：
+ * - 第一列固定 250px
+ * - 第二列占用除了 250px 和 gap 之外的所有空间
+ * - 如果有 2fr 3fr，会按比例分配剩余空间
+ * 
+ * 实际计算（1400px 屏幕）：
+ * 总宽度 = 1400px
+ * .container padding = 左32px + 右32px = 64px
+ * 可用宽度 = 1400 - 64 = 1336px
+ * 
+ * .activities-layout 内部分配：
+ * 左列（筛选器）= 250px (固定)
+ * 间距（gap） = 32px
+ * 右列（1fr） = 1336 - 250 - 32 = 1054px
+ * 
+ * 所以 1fr = 1054px（剩余空间）
+ * 如果写成 2fr，就会是 1054px * 2 = 2108px（假设有足够空间）
+ */
+.activities-layout {
+  display: grid;
+  grid-template-columns: 250px 1fr;  /* 250px 固定左列 + 剩余空间自动填充 */
+  gap: 2rem;                          /* 两列之间间距 32px */
+}
+
+/* ==================== Activity Cards ==================== */
+/* 
+ * .activities-grid - 活动卡片的响应式网格布局
+ * 
+ * 响应式规则：
+ * 1200px+ （PC大屏）: 4 列
+ * 768px-1199px （平板）: 3 列  
+ * 600px-767px （平板竖屏）: 2 列
+ * < 600px （手机）: 1 列
+ * 
+ * 默认（基础）: repeat(auto-fit, minmax(280px, 1fr))
+ * - 每列最小 280px
+ * - 自动填充可用空间
+ */
+.activities-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));  /* 基础自适应 */
+  gap: 2rem;                                                      /* 卡片间距 32px */
+  margin-top: 2rem;
+}
+
+/* 在 1200px+ 宽度强制 4 列显示 */
+@media (min-width: 1200px) {
+  .activities-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+/* 在 768-1199px 宽度强制 3 列显示 */
+@media (min-width: 768px) and (max-width: 1199px) {
+  .activities-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* 在 600-767px 宽度强制 2 列显示 */
+@media (min-width: 600px) and (max-width: 767px) {
+  .activities-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* 单个活动卡片样式 */
+.activity-card {
+  background: white;                  /* 卡片背景：白色 */
+  border-radius: 8px;
+  padding: 1.5rem;                    /* 卡片内边距：24px */
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s, box-shadow 0.3s;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  flex-direction: column;             /* 卡片内容竖向排列 */
+}
+
+/* 卡片悬停效果 */
+.activity-card:hover {
+  transform: translateY(-5px);        /* 向上浮起 5px */
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.activity-card-action {
+  margin-top: auto;
+  color: #00ff00;
+  font-weight: 700;
+  font-size: 1rem;
+  padding-top: 1rem;
+  border-top: 2px solid #00ff00;
+  text-align: right;
+  transition: all 0.3s;
+}
+
+.activity-card:hover .activity-card-action {
+  color: #333;
+  background-color: #00ff00;
+  padding: 0.75rem;
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+  margin-bottom: -1.5rem;
+  margin-top: 1rem;
+  border-radius: 0 0 8px 8px;
+  text-align: center;
+}
+
+.activity-card h3,
+.activity-card h4 {
+  color: #2c3e50;
+  margin-bottom: 0.5rem;
+}
+
+.activity-category-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  background-color: #00ff00;
+  color: #333;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
+.activity-info p {
+  margin: 0.5rem 0;
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.activity-card .view-details {
+  margin-top: auto;
+  padding: 0.75rem 1.5rem;
+  background-color: #00ff00;
+  color: #333;
+  border: none;
+  border-radius: 4px;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.3s, transform 0.2s;
+  align-self: flex-start;
+}
+
+.activity-card .view-details:hover {
+  background-color: #00cc00;
+  transform: scale(1.05);
+}
+
+/* ==================== Activity Detail Page ==================== */
+.activity-detail-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.detail-main,
+.detail-sidebar {
+  background: white;
+  border-radius: 8px;
+  padding: 2rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.detail-main h2 {
+  color: #2c3e50;
+  margin-bottom: 1rem;
+}
+
+.detail-info {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.info-item {
+  padding: 1rem;
+  background-color: #f8f9fa;
+  border-radius: 6px;
+}
+
+.info-item strong {
+  color: #2c3e50;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.activity-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.tag {
+  padding: 0.5rem 1rem;
+  background-color: #e8f4f8;
+  color: #2980b9;
+  border-radius: 20px;
+  font-size: 0.9rem;
+}
+
+/* ==================== Forms ==================== */
+.form-group {
+  margin-bottom: 15px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: bold;
+  color: #2c3e50;
+}
+
+.form-group input,
+.form-group select,
+.signup-form input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.signup-form {
+  margin-top: 1rem;
+}
+
+.signup-form button,
+button {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: #00ff00;
+  color: #333;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.signup-form button:hover,
+button:hover {
+  background-color: #00cc00;
+}
+
+.signup-form button:disabled,
+button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+/* ==================== Participants Section ==================== */
+.participants-container {
+  margin-top: 15px;
+  padding-top: 12px;
+  border-top: 1px dashed #ccc;
+}
+
+.participants-section h4,
+.participants-section h5 {
+  margin-bottom: 8px;
+  color: #1a237e;
+  font-size: 16px;
+}
+
+.participants-section ul,
+.participants-ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+.participants-section ul li,
+.participant-item {
+  padding: 0.75rem;
+  margin: 0.5rem 0;
+  background-color: #f8f9fa;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.participants-section ul li::before {
+  display: none;
+}
+
+.participant-email {
+  color: #555;
+  flex-grow: 1;
+  margin-right: 8px;
+}
+
+.delete-btn {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0.25rem 0.5rem;
+  transition: transform 0.2s;
+  color: #c62828;
+}
+
+.delete-btn:hover {
+  transform: scale(1.2);
+  background-color: #ffebee;
+}
+
+.participants-section p {
+  color: #777;
+  font-style: italic;
+}
+
+/* ==================== Filter Section ==================== */
+/* 
+ * .filter-section - 活动列表页左侧的筛选器面板
+ * 
+ * 布局说明：
+ * - 白色背景，与卡片一致
+ * - 宽度由 .activities-layout 的网格定义（固定 250px）
+ * - position: sticky 使其在滚动时保持在视图
+ * - height: fit-content 让高度自适应内容
+ * 
+ * 在响应式 CSS 中，小屏幕会改为 position: static
+ */
+.filter-section {
+  background: white;                  /* 白色背景，与卡片背景一致 */
+  padding: 1.5rem;
+  border-radius: 8px;
+  margin-bottom: 2rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  height: fit-content;                /* 高度根据内容自动调整 */
+  position: sticky;                   /* 滚动时保持在视图 */
+  top: 80px;                          /* 距离顶部 80px（导航栏高度） */
+}
+
+.filter-section label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.filter-section select {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+/* 
+ * .activities-list - 活动列表页右侧的内容区域
+ * 
+ * 这个白色背景包裹了所有的活动卡片
+ * 
+ * 为什么宽度受限？
+ * 这个容器是被 .activities-layout 网格分配的「1fr 空间」
+ * 
+ * 1fr 的含义：
+ * 在 .activities-layout: grid-template-columns: 250px 1fr; 中
+ * 1fr = 剩余空间（扣除左列 250px 和 gap 32px 后的所有空间）
+ * 
+ * 实际宽度计算示例（1400px 屏幕）：
+ * ┌─────────────────────────────────────────┐
+ * │ 屏幕宽度: 1400px                        │
+ * │ 减去 .container padding: 64px           │
+ * │ 可用宽度: 1336px                        │
+ * ├─────────────┬──────────────────────────┤
+ * │ 筛选器      │ .activities-list         │
+ * │ 250px       │ 1fr (占 1054px)          │
+ * │ (固定)      │ = 1336-250-32            │
+ * └─────────────┴──────────────────────────┘
+ * 
+ * 这个 1054px 宽度内有 padding: 2rem (32px)
+ * 所以实际卡片容器 = 1054 - 64 = 990px
+ */
+.activities-list {
+  background-color: white;            /* 白色背景容器 */
+  padding: 2rem;                      /* 内边距：32px (左右各) */
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* ==================== Stats Section ==================== */
+.stats-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
+  margin: 3rem 0;
+}
+
+.stat-card {
+  text-align: center;
+  padding: 2rem;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.stat-card h3 {
+  font-size: 2.5rem;
+  color: #3498db;
+  margin-bottom: 0.5rem;
+}
+
+.stat-card p {
+  color: #555;
+  font-size: 1rem;
+}
+
+/* ==================== Coming Soon ==================== */
+.coming-soon {
+  text-align: center;
+  padding: 4rem 2rem;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.coming-soon h2 {
+  color: #2c3e50;
+  margin-bottom: 1rem;
+}
+
+.coming-soon p {
+  color: #777;
+  font-size: 1.1rem;
+}
+
+/* ==================== Legacy/Original Styles for index.html ==================== */
+/* 警告：这些规则仅用于 index.html，不应影响新的多页面架构 */
+/* 在新架构中，使用 .navbar 替代 header，使用 .container 替代 main */
 header {
+  /* 已注释：background-color: #1a237e; - 不应用于新架构的 header */
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
-  background-color: #1a237e;
-  color: white;
+  color: #333;
   border-radius: 5px;
+  /* 此规则仅适用于 <header> 标签，新架构用 <nav class="navbar"> */
 }
 
 header h1 {
@@ -33,13 +671,20 @@ main {
   flex-wrap: wrap;
   gap: 30px;
   justify-content: center;
+  /* 已注释：max-width: 1200px; - 不应限制新架构的布局 */
+  /* 新架构使用 .container { max-width: 100%; } */
+  margin: 0 auto;
 }
 
-@media (min-width: 768px) {
+/* 已注释：@media 中的 grid-template-columns
+   原因：main 元素应该保持 flex 布局，不应转换为 grid
+   新架构用 .activities-layout 实现 250px + 1fr 的网格布局
+*/
+/* @media (min-width: 768px) {
   main {
     grid-template-columns: 2fr 1fr;
   }
-}
+} */
 
 section {
   background-color: white;
@@ -47,139 +692,64 @@ section {
   border-radius: 5px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   width: 100%;
-  max-width: 500px;
+  /* 已删除：max-width: 500px; - 旧限制会压扁 .featured-activities */
+  /* section 现在用于 .featured-activities，应该全宽 */
 }
 
-section h3 {
+/* 警告：避免 section h3 全局规则影响新架构
+   改为 section > h3（直接子元素）以限制作用范围
+   .featured-activities 内的 h3 不应被这个规则着色
+*/
+section > h3 {
   margin-bottom: 20px;
   padding-bottom: 10px;
   border-bottom: 1px solid #ddd;
   color: #1a237e;
+  /* 仅适用于直接在 section 下的 h3，不影响嵌套容器内的 h3 */
 }
 
-.activity-card {
-  margin-bottom: 15px;
-  padding: 15px;
-  border: 1px solid #ddd;
-  border-radius: 5px;
-  background-color: #f9f9f9;
+/* ==================== Footer ==================== */
+.footer,
+footer {
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  padding: 2rem;
+  margin-top: 4rem;
 }
 
-.activity-card h4 {
-  margin-bottom: 10px;
-  color: #0066cc;
+.footer p,
+footer p {
+  margin: 0.5rem 0;
+  color: #fff;
 }
 
-.activity-card p {
-  margin-bottom: 8px;
+.footer a,
+footer a {
+  color: #00ff00;
 }
 
-/* New styles for participants section */
-.participants-container {
-  margin-top: 15px;
-  padding-top: 12px;
-  border-top: 1px dashed #ccc;
-}
-
-.participants-section h5 {
-  margin-bottom: 8px;
-  color: #1a237e;
-  font-size: 16px;
-}
-
-.participants-section ul {
-  list-style-type: none;
-  padding-left: 5px;
-}
-
-.participants-section ul li {
-  padding: 4px 0;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-/* Remove the bullet point pseudo-element */
-.participants-section ul li::before {
-  display: none;
-}
-
-.participant-email {
-  flex-grow: 1;
-  margin-right: 8px;
-}
-
-.delete-btn {
-  background: none;
-  border: none;
-  color: #c62828;
-  cursor: pointer;
-  font-size: 14px;
-  padding: 2px 5px;
-  transition: all 0.2s;
-  border-radius: 3px;
-}
-
-.delete-btn:hover {
-  background-color: #ffebee;
-}
-
-.participants-section p {
-  color: #777;
-  font-style: italic;
-}
-
-.form-group {
-  margin-bottom: 15px;
-}
-
-.form-group label {
-  display: block;
-  margin-bottom: 5px;
-  font-weight: bold;
-}
-
-.form-group input,
-.form-group select {
-  width: 100%;
-  padding: 10px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  font-size: 16px;
-}
-
-button {
-  background-color: #1a237e;
-  color: white;
-  border: none;
-  padding: 10px 15px;
-  font-size: 16px;
-  border-radius: 5px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-button:hover {
-  background-color: #3949ab;
-}
-
+/* ==================== Messages ==================== */
 .message {
-  margin-top: 20px;
-  padding: 10px;
+  padding: 1rem;
   border-radius: 4px;
+  margin: 1rem 0;
+  text-align: center;
+  font-weight: 500;
 }
 
+.message.success,
 .success {
-  background-color: #e8f5e9;
-  color: #2e7d32;
-  border: 1px solid #a5d6a7;
+  background-color: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
 }
 
+.message.error,
 .error {
-  background-color: #ffebee;
-  color: #c62828;
-  border: 1px solid #ef9a9a;
+  background-color: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
 }
 
 .info {
@@ -188,13 +758,100 @@ button:hover {
   border: 1px solid #bee5eb;
 }
 
+.message.hidden,
 .hidden {
   display: none;
 }
 
-footer {
-  text-align: center;
-  margin-top: 30px;
-  padding: 20px;
-  color: #666;
+/* ==================== Responsive Design ==================== */
+@media (max-width: 768px) {
+  .navbar {
+    padding: 0.75rem 1rem;
+  }
+
+  .navbar .container {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .navbar-menu,
+  .nav-links {
+    flex-direction: column;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .navbar-menu a,
+  .nav-links a {
+    padding: 0.5rem;
+  }
+
+  .logo h2 {
+    font-size: 1.1rem;
+  }
+
+  .activities-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .filter-section {
+    position: static;
+    margin-bottom: 2rem;
+  }
+
+  .hero h1 {
+    font-size: 2rem;
+  }
+
+  .hero p {
+    font-size: 1rem;
+  }
+
+  .activities-grid {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  }
+
+  .activity-detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-info {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-section {
+    grid-template-columns: 1fr;
+  }
+
+  .container {
+    padding: 0 1rem;
+  }
+
+  .navbar {
+    padding: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .navbar-brand {
+    font-size: 1.2rem;
+  }
+
+  .navbar-menu {
+    flex-direction: column;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+  }
+
+  .hero {
+    padding: 2rem 1rem;
+  }
+
+  .hero h1 {
+    font-size: 1.5rem;
+  }
+
+  .stat-card h3 {
+    font-size: 2rem;
+  }
 }

--- a/src/static/testimonials.html
+++ b/src/static/testimonials.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Testimonials - Mergington High School</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <nav class="navbar">
+      <div class="container">
+        <a href="home.html" class="logo">
+          <h2>Mergington High School</h2>
+        </a>
+        <ul class="nav-links">
+          <li><a href="home.html">Home</a></li>
+          <li><a href="activities.html">Activities</a></li>
+          <li><a href="lectures.html">Lectures</a></li>
+          <li><a href="gallery.html">Gallery</a></li>
+          <li><a href="testimonials.html" class="active">Testimonials</a></li>
+        </ul>
+      </div>
+    </nav>
+
+    <!-- Page Header -->
+    <header class="page-header">
+      <div class="container">
+        <h1>Student Testimonials</h1>
+        <p>Hear from our students about their experiences</p>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="coming-soon-section">
+        <div class="coming-soon-card">
+          <h2>💬 Coming Soon!</h2>
+          <p>We'll be featuring testimonials and reviews from our students soon.</p>
+          <p>Share your experiences and inspire others!</p>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer>
+      <div class="container">
+        <p>&copy; 2026 Mergington High School. All rights reserved.</p>
+        <p>Building futures through excellence in education</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/src/testimonials.json
+++ b/src/testimonials.json
@@ -1,0 +1,13 @@
+{
+  "testimonials": [
+    {
+      "id": "placeholder-1",
+      "name": "Student Testimonials",
+      "text": "We'll be featuring student reviews and experiences here soon!",
+      "activity": null,
+      "rating": null,
+      "video": null,
+      "status": "coming-soon"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #8

## 概览
- 将原单页原型升级为完整多页面站点：主页、活动列表、活动详情、讲座、相册、评论
- 响应式网格布局（PC 4 列 / 平板 3 列 / 手机 1-2 列），全卡片可点击
- 后端补齐配套 API 与数据文件，重定向首页到新 `home.html`
- 清理/修复遗留 CSS 冲突，解决“页面显得过窄”的问题

## 变更摘要（按文件）
- 前端页面：新增 6 个页面 `home.html` / `activities.html` / `activity-detail.html` / `lectures.html` / `gallery.html` / `testimonials.html`（均在 `src/static/` 下）
- 前端逻辑：`home.js`（精选）、`activities-list.js`（分类筛选+卡片）、`activity-detail.js`（详情、报名/取消报名、参与者刷新）
- 样式：`styles.css` 大幅扩展，新增布局类（`.activities-layout`/`.activities-grid`/`.featured-activities`/`.activities-list`/`.filter-section`），删除/约束遗留通用选择器（`section max-width`、旧 `header/main` 等），补充详细注释
- 后端：`app.py` 新增 `/lectures` `/gallery` `/testimonials` 只读端点，根路径重定向 `home.html`；报名/取消报名接口可用
- 数据：`activities.json` 扩充为 9 条活动（新增字段 featured/category/location/instructor/full_description/tags 等）；新增占位数据 `lectures.json` / `gallery.json` / `testimonials.json`
- 错误页与文档：新增 `src/static/404.html`；更新 `src/README.md` 同步多页面与 API 用法

## 主要修复
- 移除遗留 `section { max-width: 500px; }` 导致精选/主区域过窄
- 注释或约束旧 `header/main` 的样式污染；`section h3` → `section > h3` 限定作用域
- `breadcrumb-container` 移除 1200px 限制，统一 padding 与布局

## 已验证
- 导航与各页面可访问；卡片点击跳转详情
- 分类筛选、报名/取消报名、参与者列表刷新正常
- 响应式断点（≥1200:4列，768–1199:3列，600–767:2列，<600:1列）
- API：`/activities` `/lectures` `/gallery` `/testimonials` 返回数据；报名/取消报名接口可用
- 配色统一（白 + 青柠绿 #00ff00）

## 已知遗留 / 后续建议
1) README 已更新为多页面与新端点；如需补充截图/动图可后续追加
2) Issue #5 管理员/登录权限未做；Issue #13 Bootstrap 集成待定
3) 已添加 404 页面；仍无 500 定制页；占位页（讲座/相册/评论）内容可逐步充实
4) 安全/健壮性：尚无 CSRF、防刷、输入清理；API 错误文案较简单
5) 体验：暂无搜索、多条件筛选、分页；亦未加加载动画/骨架屏

## 运行方式（本地/Codespace）
```bash
cd /workspaces/skills-integrate-mcp-with-copilot
python3 -m uvicorn src.app:app --host 0.0.0.0 --port 8000 --reload
```
访问：`http://localhost:8000`（或局域网 IP）
API 文档：`/docs` 与 `/redoc`
